### PR TITLE
more allowed exports for react router

### DIFF
--- a/.changeset/strong-shoes-sing.md
+++ b/.changeset/strong-shoes-sing.md
@@ -1,0 +1,5 @@
+---
+"@zemd/eslint-react": patch
+---
+
+more allowed exports for react router

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -78,7 +78,17 @@ export function react({
                       "@react-router/serve",
                       "@react-router/dev",
                     ].some((pkg) => isPackageExists(pkg))
-                      ? ["meta", "links", "headers", "loader", "action"]
+                      ? [
+                          "meta",
+                          "links",
+                          "headers",
+                          "loader",
+                          "action",
+                          "clientLoader",
+                          "clientAction",
+                          "handle",
+                          "shouldRevalidate",
+                        ]
                       : []),
                   ],
                 },


### PR DESCRIPTION
This pull request enhances the functionality of the React package by allowing additional exports for React Router. The changes primarily focus on expanding the set of supported exports and updating the package metadata accordingly.

### React Router Export Enhancements:

* [`.changeset/strong-shoes-sing.md`](diffhunk://#diff-8436eac9da3c1dc2bbbca890d9614543c2d77d465edbd0bc78b4ffa0af1d9337R1-R5): Added a patch update for the `@zemd/eslint-react` package to allow more exports for React Router.
* [`packages/react/src/index.ts`](diffhunk://#diff-1cee8646d2cfba37d6ce6a6e9a8d16f8caba0b99fc3a1ad0cb997ed8c7384d2eL81-R91): Expanded the list of allowed exports for React Router to include `clientLoader`, `clientAction`, `handle`, and `shouldRevalidate`. These additions enhance flexibility and support for advanced routing features.